### PR TITLE
handle alias name for switching connection

### DIFF
--- a/plugin/sqls.vim
+++ b/plugin/sqls.vim
@@ -8,7 +8,7 @@ command! SqlsShowConnections call sqls#show_connections()
 command! SqlsShowTables call sqls#show_tables()
 command! SqlsDescribeTable call sqls#describe_table()
 command! -nargs=? SqlsSwitchDatabase call sqls#switch_database(<f-args>)
-command! -nargs=? SqlsSwitchConnection call sqls#switch_connection(<f-args>)
+command! -nargs=? -complete=customlist,sqls#complete_connections SqlsSwitchConnection call sqls#switch_connection(<f-args>)
 
 nnoremap <plug>(sqls-execute-query) :<C-U>call sqls#execute_query('n')<CR>
 vnoremap <plug>(sqls-execute-query) :<C-U>call sqls#execute_query('v')<CR>


### PR DESCRIPTION
See https://github.com/lighttiger2505/sqls/pull/106

![screenshot](https://user-images.githubusercontent.com/10111/189387360-657aa175-b0cc-454e-a63b-718ccee02b4e.gif)

This change allow to complete connection name for `:SqlsSwitchConnection`.